### PR TITLE
Atmospheric pressure

### DIFF
--- a/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
+++ b/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
@@ -828,8 +828,8 @@ __global__ void cdklm_swe_2D(
             // If not land
             if (R[0][j][i] != CDKLM_DRY_FLAG) {
                 // Wind
-                const float X = windStressX(wind_stress_t_, ti+0.5, tj+0.5, NX, NY);
-                const float Y = windStressY(wind_stress_t_, ti+0.5, tj+0.5, NX, NY);
+                const float X = windStressX(wind_stress_t_, ti+0.5, tj+0.5, NX+4, NY+4);
+                const float Y = windStressY(wind_stress_t_, ti+0.5, tj+0.5, NX+4, NY+4);
 
                 // Bottom topography source terms!
                 // -g*(eta + H)*(-1)*dH/dx   * dx

--- a/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
+++ b/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
@@ -451,7 +451,7 @@ __global__ void cdklm_swe_2D(
 
         // P atmospheric
         float* p_atm_ptr_, const int p_atm_pitch_,
-        const bool use_p_atm,
+        const bool use_p_atm, const float p_atm_factor,
 
         // Boundary conditions (1: wall, 2: periodic, 3: open boundary (flow relaxation scheme))
         // Note: these are packed north, east, south, west boolean bits into an int
@@ -875,8 +875,8 @@ __global__ void cdklm_swe_2D(
                     const float dpdx = (p_atm_row[ti+1] - p_atm_row[ti-1])/(2.0f*DX);
                     const float dpdy = (p_atm_row_p[ti] - p_atm_row_m[ti])/(2.0f*DY);
 
-                    atm_pressure_x = -dpdx*h/RHO_O;
-                    atm_pressure_y = -dpdy*h/RHO_O;
+                    atm_pressure_x = -p_atm_factor*dpdx*h/RHO_O;
+                    atm_pressure_y = -p_atm_factor*dpdy*h/RHO_O;
                 }
 
 

--- a/src/gpuocean/gpu_kernels/common.cu
+++ b/src/gpuocean/gpu_kernels/common.cu
@@ -608,10 +608,10 @@ texture<float, cudaTextureType2D> windstress_Y_next;
 /**
   * Returns the wind stress, trilinearly interpolated in space and time
   * @param wind_stress_t_ \in [0, 1] determines the temporal interpolation (0=current, 1=next)
-  * @param ti_ Location of this thread along the x-axis in number of cells (NOTE: half indices)
-  * @param tj_ Location of this thread along the y-axis in number of cells (NOTE: half indices)
-  * @param nx_ Number of cells along x axis
-  * @param ny_ Number of cells along y axis
+  * @param ti_ Location of this thread along the x-axis in number of cells (NOTE: half indices, including ghost cells)
+  * @param tj_ Location of this thread along the y-axis in number of cells (NOTE: half indices, including ghost cells)
+  * @param nx_ Number of cells along x axis including ghost cells
+  * @param ny_ Number of cells along y axis including ghost cells
   */
 __device__ float windStressX(float wind_stress_t_, float ti_, float tj_, int nx_, int ny_) {
     

--- a/test/oneLayer_2D_tests.py
+++ b/test/oneLayer_2D_tests.py
@@ -37,11 +37,12 @@ from schemes.KP07_test import KP07test
 from schemes.NetCDF_test import NetCDFtest
 from schemes.NetCDF_test import NetCDFtest
 from schemes.ConservationOfMass_test import ConservationOfMassTest
+from schemes.AtmosphericPressure_test import AtmosphericPressureTest
 
 
 def printSupportedSchemes():
     print("Supported schemes:")
-    print("0: All, 1: FBL, 2: CTCS, 3: CDKLM16, 4: KP07, 5: NetCDF interface, 6: Conservation of mass")
+    print("0: All, 1: FBL, 2: CTCS, 3: CDKLM16, 4: KP07, 5: NetCDF interface, 6: Conservation of mass, 7: Atmospheric pressure")
     
 
 if (len(sys.argv) < 2):
@@ -64,7 +65,8 @@ if (jenkins):
 # Define the tests that will be part of our test suite:
 test_classes_to_run = None
 if scheme == 0:
-    test_classes_to_run = [FBLtest, CTCStest, CDKLM16test, KP07test, NetCDFtest, ConservationOfMassTest]
+    test_classes_to_run = [FBLtest, CTCStest, CDKLM16test, KP07test, NetCDFtest, 
+                           ConservationOfMassTest, AtmosphericPressureTest]
 elif scheme == 1:
     test_classes_to_run = [FBLtest]
 elif scheme == 2:
@@ -77,6 +79,8 @@ elif scheme == 5:
     test_classes_to_run = [NetCDFtest]
 elif scheme == 6:
     test_classes_to_run = [ConservationOfMassTest]
+elif scheme == 7:
+    test_classes_to_run = [AtmosphericPressureTest]
 else:
     print("Error: " + str(scheme) + " is not a supported scheme...")
     printSupportedSchemes()

--- a/test/oneLayer_2D_tests.py
+++ b/test/oneLayer_2D_tests.py
@@ -37,12 +37,12 @@ from schemes.KP07_test import KP07test
 from schemes.NetCDF_test import NetCDFtest
 from schemes.NetCDF_test import NetCDFtest
 from schemes.ConservationOfMass_test import ConservationOfMassTest
-from schemes.AtmosphericPressure_test import AtmosphericPressureTest
+from schemes.RealisticForcing_Test import RealisticForcingTest
 
 
 def printSupportedSchemes():
     print("Supported schemes:")
-    print("0: All, 1: FBL, 2: CTCS, 3: CDKLM16, 4: KP07, 5: NetCDF interface, 6: Conservation of mass, 7: Atmospheric pressure")
+    print("0: All, 1: FBL, 2: CTCS, 3: CDKLM16, 4: KP07, 5: NetCDF interface, 6: Conservation of mass, 7: Realistic forcing")
     
 
 if (len(sys.argv) < 2):
@@ -66,7 +66,7 @@ if (jenkins):
 test_classes_to_run = None
 if scheme == 0:
     test_classes_to_run = [FBLtest, CTCStest, CDKLM16test, KP07test, NetCDFtest, 
-                           ConservationOfMassTest, AtmosphericPressureTest]
+                           ConservationOfMassTest, RealisticForcingTest]
 elif scheme == 1:
     test_classes_to_run = [FBLtest]
 elif scheme == 2:
@@ -80,7 +80,7 @@ elif scheme == 5:
 elif scheme == 6:
     test_classes_to_run = [ConservationOfMassTest]
 elif scheme == 7:
-    test_classes_to_run = [AtmosphericPressureTest]
+    test_classes_to_run = [RealisticForcingTest]
 else:
     print("Error: " + str(scheme) + " is not a supported scheme...")
     printSupportedSchemes()

--- a/test/schemes/AtmosphericPressure_test.py
+++ b/test/schemes/AtmosphericPressure_test.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""
+This software is part of GPU Ocean. 
+
+Copyright (C) 2022 SINTEF Digital
+
+This python module implements tests related to atmospheric pressure
+implemented in the CDKLM scheme
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import unittest
+import numpy as np
+import sys
+import gc
+
+from testUtils import *
+
+from gpuocean.SWEsimulators import CDKLM16
+from gpuocean.utils import Common
+
+class AtmosphericPressureTest(unittest.TestCase):
+    def setUp(self):
+        self.sim_args = {
+            "gpu_ctx": Common.CUDAContext(),
+            "nx": 500, "ny": 400, "dx": 800, "dy": 500,
+            "g": 9.81, "dt": 0.0, "f": 0.0, "r": 0.0,
+            "rho_o": 1015,
+        }
+
+        self.dataShape = (self.sim_args["ny"]+4, self.sim_args["nx"]+4)
+
+        self.init_args = {
+            "eta0": np.zeros(self.dataShape, dtype=np.float32),
+            "hu0" : np.zeros(self.dataShape, dtype=np.float32),
+            "hv0" : np.zeros(self.dataShape, dtype=np.float32),
+            "H"  : np.ones((self.dataShape[0]+1, self.dataShape[1]+1), dtype=np.float32)*100
+        }
+
+        self.sim = None
+
+        self.p_atm = np.ones(self.dataShape, np.float32)*100000
+
+    def setBumpyP(self, balanced_eta=True):
+        x = np.linspace(0, 2*np.pi, int((self.dataShape[1]-4)/2))
+        y = np.linspace(0, 2*np.pi, self.dataShape[0]-4)
+
+        for i in range(len(x)):
+            for j in range(len(y)):
+                self.p_atm[j, i                             ] += 0.5*(1 - np.cos(x[i]))*(1 - np.cos(y[j]))*2000
+                self.p_atm[j, i + int(self.sim_args["nx"]/2)] += 0.5*(np.cos(x[i]) - 1)*(1 - np.cos(y[j]))*2000
+
+                if balanced_eta:
+                    self.init_args["eta0"][j, i                             ] = -0.5*(1 - np.cos(x[i]))*(1 - np.cos(y[j]))*2000 / (self.sim_args["g"]*self.sim_args["rho_o"])
+                    self.init_args["eta0"][j, i + int(self.sim_args["nx"]/2)] = -0.5*(np.cos(x[i]) - 1)*(1 - np.cos(y[j]))*2000 / (self.sim_args["g"]*self.sim_args["rho_o"])
+            
+    def setLinearXP(self, balanced_eta=True):
+        fullx = np.linspace(-1.5, self.sim_args["nx"]+1.5, self.sim_args["nx"]+4)
+        fully = np.linspace(-1.5, self.sim_args["ny"]+1.5, self.sim_args["ny"]+4)
+        for i in range(len(fullx)):
+            for j in range(len(fully)):
+                # Linear along x
+                self.p_atm[j, i] += - 2000 + 4000*fullx[i]/ self.sim_args["nx"]
+                if balanced_eta:
+                    self.init_args["eta0"][j, i] = - 4000*fullx[i]/(self.sim_args["nx"] * (self.sim_args["g"]*self.sim_args["rho_o"]))
+
+    def setLinearYP(self, balanced_eta=True):
+        fullx = np.linspace(-1.5, self.sim_args["nx"]+1.5, self.sim_args["nx"]+4)
+        fully = np.linspace(-1.5, self.sim_args["ny"]+1.5, self.sim_args["ny"]+4)
+        for i in range(len(fullx)):
+            for j in range(len(fully)):
+                # Linear along y
+                self.p_atm[j, i]  += - 2000 + 4000*fully[j]/ self.sim_args["ny"]
+                if balanced_eta:
+                    self.init_args["eta0"][j, i] = - 4000*fully[j]/(self.sim_args["ny"] * (self.sim_args["g"]*self.sim_args["rho_o"]))
+
+    def setLinearDiagP(self, balanced_eta=True):
+        fullx = np.linspace(-1.5, self.sim_args["nx"]+1.5, self.sim_args["nx"]+4)
+        fully = np.linspace(-1.5, self.sim_args["ny"]+1.5, self.sim_args["ny"]+4)
+        for i in range(len(fullx)):
+            for j in range(len(fully)):
+                # Linear on the diagonal
+                self.p_atm[j, i] += - 2000 + 4000*(fullx[i] + fully[j])/ (self.sim_args["nx"] + self.sim_args["ny"])
+                if balanced_eta:
+                    self.init_args["eta0"][j, i] = - 4000*(fullx[i] + fully[j])/((self.sim_args["nx"] + self.sim_args["ny"]) * (self.sim_args["g"]*self.sim_args["rho_o"]))
+
+    def tearDown(self) -> None:
+        if self.sim != None:
+            self.sim.cleanUp()
+            self.sim = None
+
+        self.init_args = None
+
+        if self.sim_args["gpu_ctx"] is not None:
+            self.assertEqual(sys.getrefcount(self.sim_args["gpu_ctx"]), 2)
+            self.gpu_ctx = None
+        
+        gc.collect() # Force run garbage collection to free up memory
+
+
+    def check_steady_state(self, places=0):
+        eta1, hu1, hv1 = self.sim.download(interior_domain_only=True)
+        if places == 0:
+            self.assertEqual(np.abs(hu1[1:-1, 1:-1]).max(), 0, msg='Not steady state. Got np.abs(hu1).max() = '+str(np.abs(hu1).max()))
+            self.assertEqual(np.abs(hv1[1:-1, 1:-1]).max(), 0, msg='Not steady state. Got np.abs(hv1).max() = '+str(np.abs(hv1).max()))
+            etadiff = eta1 - self.init_args["eta0"][2:-2, 2:-2]
+            self.assertEqual(np.abs(etadiff[1:-1, 1:-1]).max(), 0, msg='Not steady state. Got np.abs(etadiff).max() = '+str(np.abs(etadiff).max()))
+            
+        else:
+            self.assertAlmostEqual(np.abs(hu1[1:-1, 1:-1]).max(), 0, places=places)
+            self.assertAlmostEqual(np.abs(hv1[1:-1, 1:-1]).max(), 0, places=places)
+            etadiff = eta1 - self.init_args["eta0"][2:-2, 2:-2]
+            self.assertAlmostEqual(np.abs(etadiff[1:-1, 1:-1]).max(), 0, places=places)
+
+    def test_steady_state_lake_at_rest(self):
+        self.sim = CDKLM16.CDKLM16(**self.sim_args, **self.init_args, p_atm=self.p_atm)
+        self.sim.step(3600)
+        self.check_steady_state()
+
+    def test_steady_state_linear_x(self):
+        self.setLinearXP()
+        self.sim = CDKLM16.CDKLM16(**self.sim_args, **self.init_args, p_atm=self.p_atm)
+        self.sim.step(3600)
+        self.check_steady_state(places=3)
+
+    def test_steady_state_linear_y(self):
+        self.setLinearYP()
+        self.sim = CDKLM16.CDKLM16(**self.sim_args, **self.init_args, p_atm=self.p_atm)
+        self.sim.step(3600)
+        self.check_steady_state(places=3)
+
+    def test_steady_state_linear_diag(self):
+        self.setLinearDiagP()
+        self.sim = CDKLM16.CDKLM16(**self.sim_args, **self.init_args, p_atm=self.p_atm)
+        self.sim.step(3600)
+        self.check_steady_state(places=2)
+
+    def test_steady_state_bumps(self):
+        self.setBumpyP()
+        self.sim = CDKLM16.CDKLM16(**self.sim_args, **self.init_args, p_atm=self.p_atm)
+        self.sim.step(3600)
+        self.check_steady_state(places=2)
+

--- a/test/schemes/ConservationOfMass_test.py
+++ b/test/schemes/ConservationOfMass_test.py
@@ -4,7 +4,8 @@ This software is part of GPU Ocean.
 
 Copyright (C) 2022 SINTEF Digital
 
-This python module implements regression tests for the CDKLM16 scheme.
+This python module implements regression tests conservation of mass
+related to Kelvin waves in a domain with mixed boundary conditions.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Two-in-one PR (sorry).
1) Atmospheric forcing (WiP) - Current status: Naive implementation that shows correct behavior. Will use textures before PR is ready
2) Bug fix when fetching wind forcing from textures.
See commits:
* [419543b](https://github.com/metno/gpuocean/commit/419543bb7fb6fbdcf1fbc76e33846575fd62c6fc)
* [d02e572](https://github.com/metno/gpuocean/commit/d02e5724357199131a5be7f7f2d0def7ed2c88e5)
The bug caused wrong values to be fetched from the texture. The NetCDF initializer read the same domain for wind as for eta, hu and hv, meaning that the texture contains data for (nx+4, ny+4). The fetch however assumed that it was normalized based on (nx, ny) values, even though the input index was index in interior domain + ghost cells + 0.5.

@setmar: Could you just review the bug fix for wind now (meaning, whenever it suits you), and then we can do the rest later.