### PR TITLE
Conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,9 @@ We recommend that you set up your python environment using the package manager C
     conda config --remove channels defaults
     ```
     Or install [miniforge](https://github.com/conda-forge/miniforge) instead, which "holds a minimal installer for Conda specific to conda-forge."
-- Install jupyter notebook (unless you already have it installed on your system) by opening a terminal (or Anaconda prompt if on Windows) and type
+- Start with installing jupyter notebook and the conda extensions that allows jupyter notebooks to select conda environments as kernels (for better convenience, it is necessary to install those in the base environment). To do so, open a terminal (or Anaconda prompt if on Windows) and type
     ```
-    conda install -c conda-forge jupyter
-    ```
-- Install the conda extensions that allows jupyter notebook to select conda environments as kernels:
-    ```
-    conda install -c conda-forge nb_conda_kernels
+    conda install -c conda-forge nb_conda_kernels jupyter
     ```
 - Create a new conda environment according to the environment file in this repository
     ```

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -10,14 +10,12 @@ dependencies:
 - conda-build
 - numpy
 - matplotlib=3.3.3
-- jupyter
 - netcdf4
 - pytest
 - xmlrunner
 - scipy
 - pandas
 - pytables
-- nb_conda_kernels
 - nbdime
 - mpi4py
 - openssl
@@ -26,6 +24,7 @@ dependencies:
 - pyproj
 - pytools
 - ffmpeg
+- seawater
 # Activate environment and install the following packages using pip:
 # $ conda activate gpuocean
 # $ pip3 install --trusted-host files.pythonhosted.org --no-deps -U pycuda

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,6 +1,6 @@
 # Assumes that conda, pip and build-essentials are installed
 ---
-name: gpuocean
+name: gpuocean-test
 channels:
 - conda-forge
 
@@ -8,6 +8,7 @@ channels:
 dependencies:
 - python=3.7
 - conda-build
+- ipykernel
 - numpy
 - matplotlib=3.3.3
 - netcdf4

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,6 +1,6 @@
 # Assumes that conda, pip and build-essentials are installed
 ---
-name: gpuocean-test
+name: gpuocean
 channels:
 - conda-forge
 
@@ -8,7 +8,6 @@ channels:
 dependencies:
 - python=3.7
 - conda-build
-- ipykernel
 - numpy
 - matplotlib=3.3.3
 - netcdf4

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -8,6 +8,7 @@ channels:
 dependencies:
 - python=3.7
 - conda-build
+- ipykernel
 - numpy
 - matplotlib=3.3.3
 - netcdf4


### PR DESCRIPTION
Feedback from Nils: Unclear why `juptyer` and `nb_conda_kernels` installed in base AND environment. 

It is convenient to have those in base, but then `ipykernel` needed in environment.