### PR TITLE
Fix: Bathymetry for open BC in the ghost cell halo

### DIFF
--- a/src/gpuocean/utils/Common.py
+++ b/src/gpuocean/utils/Common.py
@@ -1401,7 +1401,7 @@ class Bathymetry:
                 self.global_size, self.local_size, self.gpu_stream, \
                 self.nx, self.ny, self.halo_x, self.halo_y, \
                 self.Bi.data.gpudata, self.Bi.pitch)
-        else:
+        elif (self.boundary_conditions.north == 1) and (self.boundary_conditions.south == 1):
             self.closed_boundary_intersections_NS.prepared_async_call( \
                 self.global_size, self.local_size, self.gpu_stream, \
                 self.nx, self.ny, self.halo_x, self.halo_y, \
@@ -1413,7 +1413,7 @@ class Bathymetry:
                 self.global_size, self.local_size, self.gpu_stream, \
                 self.nx, self.ny, self.halo_x, self.halo_y, \
                 self.Bi.data.gpudata, self.Bi.pitch)
-        else:
+        elif (self.boundary_conditions.north == 1) and (self.boundary_conditions.south == 1):
             self.closed_boundary_intersections_EW.prepared_async_call( \
                 self.global_size, self.local_size, self.gpu_stream, \
                 self.nx, self.ny, self.halo_x, self.halo_y, \


### PR DESCRIPTION
In the constructor of the `Bathymetry`-class, the method`_boundaryCondtions` iscalled to adjust the bathymetry for the according BC. 

So far, for all non-periodic (i.e. including open) BC the kernels for "closed" BC got called. 

Now, the bathymetry in the bathymetry stays unmodified for open BC.