### PR TITLE
Fix for fluxes over wet/dry faces along land mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,31 @@ We recommend that you set up your python environment using the package manager C
     sudo apt-get install texlive-latex-base texlive-latex-extra texlive-fonts-recommended dvipng cm-super
     ```
 
+## Debugging 
+
+When using VSC, the following `launch.json` content maybe helpful:
+```
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {"name":"Python: Current File","type":"python","request":"launch","program":"${file}","console":"integratedTerminal","justMyCode":true},
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "cwd": "${fileDirname}",
+            "python": "which python"
+        }
+    ]
+}
+```
+
 You should now be able to start a jupyter notebook server, open one of our notebooks, select the conda environment 'gpuocean' as kernel, and run the code. 
 
 Have fun!

--- a/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
+++ b/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
@@ -266,9 +266,9 @@ float3 computeFFaceFlux(const int i, const int j, const int bx,
     const float um = R[1][l][k  ];
     float vp = R[2][l][k+1];
     float vm = R[2][l][k  ];
-    
-    //Check if dry: if so return zero flux
-    if (eta_bar_p == CDKLM_DRY_FLAG || eta_bar_m == CDKLM_DRY_FLAG) {
+
+    // Check if all dry: if so return zero flux
+    if (eta_bar_m == CDKLM_DRY_FLAG && eta_bar_p == CDKLM_DRY_FLAG) {
         return make_float3(0.0f, 0.0f, 0.0f);
     }
 
@@ -298,6 +298,16 @@ float3 computeFFaceFlux(const int i, const int j, const int bx,
     // Our flux variables Q=(h, u, v)
     const float3 Qp = make_float3(hp, Rp.x, Rp.y);
     const float3 Qm = make_float3(hm, Rm.x, Rm.y);
+
+    // Check if wet-dry face: if so balance potential energy of water level
+    // NOTE: Mathematical documentation of this heuristic needed
+    if (eta_bar_m == CDKLM_DRY_FLAG && eta_bar_p != CDKLM_DRY_FLAG) {
+        return make_float3(0.0f, 0.5f*GRAV*Qp.x*Qp.x, 0.0f);
+    }
+
+    if (eta_bar_m != CDKLM_DRY_FLAG && eta_bar_p == CDKLM_DRY_FLAG){
+        return make_float3(0.0f, 0.5f*GRAV*Qm.x*Qm.x, 0.0f);
+    }
 
     // Computed flux
     return CDKLM16_flux(Qm, Qp);
@@ -330,8 +340,8 @@ float3 computeGFaceFlux(const int i, const int j, const int by,
     const float vp = R[2][l+1][k];
     const float vm = R[2][l  ][k];
 
-    //Check if dry: if so return zero flux
-    if (eta_bar_p == CDKLM_DRY_FLAG || eta_bar_m == CDKLM_DRY_FLAG) {
+    // Check if all dry: if so return zero flux
+    if (eta_bar_m == CDKLM_DRY_FLAG && eta_bar_p == CDKLM_DRY_FLAG) {
         return make_float3(0.0f, 0.0f, 0.0f);
     }
     
@@ -363,6 +373,16 @@ float3 computeGFaceFlux(const int i, const int j, const int by,
     const float3 Qp = make_float3(hp, Rp.y, Rp.x);
     const float3 Qm = make_float3(hm, Rm.y, Rm.x);
 
+    // Check if wet-dry face: if so balance potential energy of water level'
+    // NOTE: Mathematical documentation of this heuristic needed
+    if (eta_bar_m == CDKLM_DRY_FLAG && eta_bar_p != CDKLM_DRY_FLAG) {
+        return make_float3(0.0f, 0.0f, 0.5f*GRAV*Qp.x*Qp.x);
+    }
+
+    if (eta_bar_m != CDKLM_DRY_FLAG && eta_bar_p == CDKLM_DRY_FLAG){
+        return make_float3(0.0f, 0.0f, 0.5f*GRAV*Qm.x*Qm.x);
+    }
+    
     // Computed flux
     // Note that we swap back u and v
     const float3 flux = CDKLM16_flux(Qm, Qp);

--- a/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
+++ b/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
@@ -300,7 +300,19 @@ float3 computeFFaceFlux(const int i, const int j, const int bx,
     const float3 Qm = make_float3(hm, Rm.x, Rm.y);
 
     // Check if wet-dry face: if so balance potential energy of water level
-    // NOTE: Mathematical documentation of this heuristic needed
+    
+    // NOTE: 0-fluxes over wet-dry faces, lead to non-physical waves
+    // Hence, we want to control the flux-difference in one way or another
+    // (Wall boundary would be desirable, but are inaccessible)
+    // The chosen method simply balances the potential-energy flux contribution that acts wet -> dry, by:
+    //    F (dry -> wet) = 1/2 g h(wet)^2
+    // such that this conserves lakes at rest within numerical precison,
+    // but actually ignores wave speeds and simply assumes a symmetric Riemann-fan. 
+    // [There are actually now physical values defined on dry cells 
+    // and alternative approaches lead to new issues. 
+    // One such alternative would be to set "artificial" values on dry cells, e.g.,
+    //    Qm = make_float3(hp, 0.0f, 0.0f); 
+    // what also conserves lakes at rest but behaves criticial in presence of waves]
     if (eta_bar_m == CDKLM_DRY_FLAG && eta_bar_p != CDKLM_DRY_FLAG) {
         return make_float3(0.0f, 0.5f*GRAV*Qp.x*Qp.x, 0.0f);
     }
@@ -374,7 +386,7 @@ float3 computeGFaceFlux(const int i, const int j, const int by,
     const float3 Qm = make_float3(hm, Rm.y, Rm.x);
 
     // Check if wet-dry face: if so balance potential energy of water level'
-    // NOTE: Mathematical documentation of this heuristic needed
+    // NOTE: See docu in "computeFFaceFlux"
     if (eta_bar_m == CDKLM_DRY_FLAG && eta_bar_p != CDKLM_DRY_FLAG) {
         return make_float3(0.0f, 0.0f, 0.5f*GRAV*Qp.x*Qp.x);
     }


### PR DESCRIPTION
The potential energy contribution in the fluxes was unbalanced (wet/dry faces got assigned 0 flux) and (strong) artificial waves along the landmask were created.

Now, the potential energy on a wet/dry faces get equally balanced (numerical differences since less intermediate calculations are necessary and errors in magnitude of machine precision). 