### PR TITLE
Using central-upwinding for 3rd flux component

### DIFF
--- a/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
+++ b/src/gpuocean/gpu_kernels/CDKLM16_kernel.cu
@@ -131,10 +131,14 @@ __device__ float3 CDKLM16_flux(float3 Qm, float3 Qp) {
     }
     
     float3 F;
-
+  
+    // Q = [h, u, v]
+    // F = [hu, h*u*u + 0.5*g*h*h, h*u*v]
     F.x = ((ap*Fm.x - am*Fp.x) + ap*am*(Qp.x-Qm.x))/(ap-am);
     F.y = ((ap*Fm.y - am*Fp.y) + ap*am*(Fp.x-Fm.x))/(ap-am);
-    F.z = (Qm.y + Qp.y > 0) ? Fm.z : Fp.z; //Upwinding to be consistent
+    F.z = ((ap*Fm.z - am*Fp.z) + ap*am*(Qp.x*Qp.z - Qm.x*Qm.z))/(ap-am); // Standard central-upwind scheme
+    //F.z = (Qm.y + Qp.y > 0) ? Fm.z : Fp.z; // This upwinding is used for "consistency" according to CDKLM ref, but it gives artifacts
+
 
     return F;
 }


### PR DESCRIPTION
Every now and then, I've seen some faint lines in our simulation results that has bugged me. However, I have blamed them on grid effects and pretended that my mind is at ease.
Now, these artefacts have turned up more clearly than ever, and I finally found the bug.

The CDKLM was proposed with standard upwinding (see eq (3.4) in their paper) for the 3rd (2nd) component in the F (G) flux, rather than the central-upwind flux used elsewhere. They claimed it had to be so for the scheme to be well-balanced, and point to the proof of their Theorem 3.1. However, eq (3.4) is never used in the proof of theorem 3.1. They only design their scheme for some jet line geostrophies, which means that u (or v) is fixed zero, causing the huv flux to be zero no matter how you upwind it or not. So, as far as I can see, there are no reason to use anything else than a central-upwind flux for all components in the flux.

# Demo
In the second to last output with plots in this notebook, the bug is clearly visible (run with current gpuocean main):
https://github.com/havahol/miscGPUOcean/blob/9447abe1199389afb6433258926ded55241e2216/realWorldSim/SyntheticLandMaks.ipynb
In this commit, I've run the same notebook with the PR:
https://github.com/havahol/miscGPUOcean/blob/dad5cb07f767ffc80834956bf940e73a3b4d08f5/realWorldSim/SyntheticLandMaks.ipynb

# Disclaimer
Many tests will fail now. I think it is more important to get this bugfix into main since we are running many experiments at the moment. I will make PR with updated tests later.